### PR TITLE
Rename project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# [![>bootenv](http://bootenv.com/img/logo-light-transparent-readme-files.png)](http://bootenv.com)-JAVA-UTILITY
+# [![>bootenv](http://bootenv.com/img/logo-light-transparent-readme-files.png)](http://bootenv.com)-JAVA
 
 [![license](https://img.shields.io/badge/license-Apache_2.0-blue.svg)]()
 [![engine](https://img.shields.io/badge/JDK-v1.7+-yellow.svg)]()
 [![gradle](https://img.shields.io/badge/gradle-v2.4-blue.svg)]()
-[![Build Status](https://travis-ci.org/bootenv/bootenv-java-utility.svg?branch=master)](https://travis-ci.org/bootenv/bootenv-java-utility)
-[![Coverage Status](https://coveralls.io/repos/bootenv/bootenv-java-utility/badge.svg)](https://coveralls.io/r/bootenv/bootenv-java-utility)
+[![Build Status](https://travis-ci.org/bootenv/bootenv-java.svg?branch=master)](https://travis-ci.org/bootenv/bootenv-java)
+[![Coverage Status](https://coveralls.io/repos/bootenv/bootenv-java/badge.svg)](https://coveralls.io/r/bootenv/bootenv-java)
 
 > It’s simple! Java utility methods to make using the environment properties more pleasant. `:wq`
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,13 @@ buildscript {
 
 repositories {
     mavenLocal()
+    mavenCentral()
     jcenter()
 }
 
 dependencies {
     compile group: 'com.google.guava', name: 'guava', version: '18.0'
-    
+
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.12'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.3'
 
@@ -36,8 +37,8 @@ jar {
     manifest {
         attributes(
             'Implementation-Version': "${version}",
-            'Implementation-Title': 'Bootenv - Java utility',
-            'Created-By': 'Bootenv',
+            'Implementation-Title': '>bootenv - Java',
+            'Created-By': '>bootenv',
             'Built-By': System.getProperty('user.name'),
             'Built-Date': new Date().format('yyyy-MM-dd HH:mm:ss')
         )

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'bootenv-java-utility'
+rootProject.name = 'bootenv'

--- a/src/main/java/org/bootenv/Environment.java
+++ b/src/main/java/org/bootenv/Environment.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.bootenv.utility;
+package org.bootenv;
 
 import com.google.common.base.Optional;
 
@@ -37,7 +37,7 @@ public interface Environment {
      *
      * @return <tt>true</tt> only if the environment has a property
      */
-    boolean has(String key);
+    boolean hasProperty(String key);
 
     /**
      * Checks if a key is equals to <tt>true</tt> if it's not present will return <tt>false</tt>

--- a/src/main/java/org/bootenv/EnvironmentImpl.java
+++ b/src/main/java/org/bootenv/EnvironmentImpl.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.bootenv.utility;
+package org.bootenv;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
@@ -40,7 +40,7 @@ public class EnvironmentImpl implements Environment {
     }
 
     @Override
-    public boolean has(final String key) {
+    public boolean hasProperty(final String key) {
         LOG.debug("Checking is Environment has the [{}] property...", key);
         Optional<String> property = getOptionalProperty(key);
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.bootenv.utility" level="DEBUG"/>
+    <logger name="org.bootenv" level="DEBUG"/>
 
     <root level="WARN">
         <appender-ref ref="STDOUT"/>

--- a/src/test/java/org/bootenv/EnvironmentTest.java
+++ b/src/test/java/org/bootenv/EnvironmentTest.java
@@ -1,7 +1,9 @@
-package org.bootenv.utility;
+package org.bootenv;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+import org.bootenv.Environment;
+import org.bootenv.EnvironmentImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,10 +54,10 @@ public final class EnvironmentTest {
     public void testHas() throws Exception {
         replayAll();
 
-        assertTrue(environment.has(KEY1));
-        assertTrue(environment.has(KEY2));
-        assertFalse(environment.has(KEY3));
-        assertFalse(environment.has(KEY4));
+        assertTrue(environment.hasProperty(KEY1));
+        assertTrue(environment.hasProperty(KEY2));
+        assertFalse(environment.hasProperty(KEY3));
+        assertFalse(environment.hasProperty(KEY4));
 
         verifyAll();
     }
@@ -152,10 +154,10 @@ public final class EnvironmentTest {
 
         replayAll();
 
-        assertTrue(environment.has(KEY1));
-        assertTrue(environment.has(KEY2));
-        assertFalse(environment.has(KEY3));
-        assertFalse(environment.has(KEY4));
+        assertTrue(environment.hasProperty(KEY1));
+        assertTrue(environment.hasProperty(KEY2));
+        assertFalse(environment.hasProperty(KEY3));
+        assertFalse(environment.hasProperty(KEY4));
 
         List<String> keys = Lists.newArrayList(environment.getKeys());
         assertEquals(2, keys.size());


### PR DESCRIPTION
@bootenv/owners Rename project to simple `bootenv`, now we can use on gradle based projects, like:

```
compile group: 'org.bootenv, name: 'bootenv', version: '1.0.0'
```

Signed-off-by: Andrés Amado acactown@gmail.com
